### PR TITLE
D jh dungeonentry

### DIFF
--- a/GameManager.gd
+++ b/GameManager.gd
@@ -13,6 +13,7 @@ var MULTIPLAYER_MENU = "res://UI/screens/MultiplayerSetup/MultiplayerSetup.tscn"
 var LOBBY_SCENE = "res://UI/screens/Lobby/lobbyMenu.tscn"
 var JOIN_SERVER_SCENE = "res://UI/screens/MultiplayerSetup/JoinServerMenu/JoinServerMenu.tscn"
 var OVERWORLD_SCENE = "res://World/OverWorld.tscn"
+var DUNGEON_SCENE = "res://World/Dungeon/Dungeon.tscn"
 
 
 signal level_changed(level)

--- a/GameManager.gd
+++ b/GameManager.gd
@@ -14,7 +14,7 @@ var LOBBY_SCENE = "res://UI/screens/Lobby/lobbyMenu.tscn"
 var JOIN_SERVER_SCENE = "res://UI/screens/MultiplayerSetup/JoinServerMenu/JoinServerMenu.tscn"
 var OVERWORLD_SCENE = "res://World/OverWorld.tscn"
 var DUNGEON_SCENE = "res://World/Dungeon/Dungeon.tscn"
-
+var GAME_OVER_SCENE = "res://UI/screens/GameOver/GameOver.tscn"
 
 signal level_changed(level)
 signal points_changed(points)

--- a/GameManager.gd
+++ b/GameManager.gd
@@ -1,6 +1,6 @@
 extends Node
 
-export(int) var initial_seed = 0
+export(int) var initial_seed = 0 setget set_seed
 var level = 0 setget set_level
 var levelSeed = 0
 var overworld_entrance_position
@@ -33,15 +33,44 @@ func add_points(value):
 func _ready():
 	print("game manage ready")
 
-
 func reset():
 	overworld_entrance_position = null
 	level = 0
 	points = 0
 	
-func createSeed():
+	if has_node("/root/world"): # Game is in progress.
+		get_node("/root/world").queue_free()
+	get_node("/root/players").queue_free()
+	
+func create_seed():
 	if (initial_seed == 0):
 		randomize()
 		initial_seed = randi()
 	print("Initial Game Seed:"+str(initial_seed))
 	seed(initial_seed)
+	
+remote func get_seed():
+	GameManager.initial_seed
+	
+remote func set_seed(new_seed):
+	initial_seed = new_seed
+
+func change_scene(scene_resource, player = null):
+	# load new scene
+	var new_world = load(scene_resource).instance()
+	new_world.name = "world"
+	var root = get_node("/root")
+	
+	# clean up old one
+	if (has_node("/root/world")):
+		var prev_world = get_node("/root/world")
+		prev_world.name = "previous_world"
+		prev_world.queue_free()
+	
+	root.add_child(new_world)
+	
+	# fix players index
+	if (has_node("/root/players")):
+		root.move_child(get_node("/root/players"), root.get_child_count() -1)
+		
+	

--- a/HitBoxes_HurtBoxes/HurtBox.gd
+++ b/HitBoxes_HurtBoxes/HurtBox.gd
@@ -23,7 +23,7 @@ func start_invicibility(duration):
 
 func create_hit_effect():
 	var effect = HitEffect.instance()
-	var main = get_tree().current_scene
+	var main = get_parent()
 	effect.global_position = global_position + effect_offset
 	main.add_child(effect)
 

--- a/LobbyManager.gd
+++ b/LobbyManager.gd
@@ -105,14 +105,7 @@ func startGame():
 	for player in LobbyManager.player_info:
 		rpc_id(player, "pre_configure_game")
 	pre_configure_game()
-	
-	
-	# remove the player from the overworld scene - check
-	# refactor overworld for players node - check...
-	# Fire off the pre_config_here
-	# remove player node from overworld and programtically add all
-	# ensure pre_config fires on all clients and game starts
-	#get_tree().change_scene(GameManager.OVERWORLD_SCENE)
+
 	
 func joinGame(ip, port):
 	var peer = NetworkedMultiplayerENet.new()

--- a/LobbyManager.gd
+++ b/LobbyManager.gd
@@ -30,7 +30,7 @@ func _player_disconnected(id):
 # Only called on clients, not server. Will go unused; not useful here.
 func _connected_ok():
 	print("connected!")
-	GameManager.change_scene(GameManager.LOBBY_SCENE)
+	get_tree().change_scene(GameManager.LOBBY_SCENE)
 
 # Server kicked us; show error and abort.
 func _server_disconnected():

--- a/LobbyManager.gd
+++ b/LobbyManager.gd
@@ -115,8 +115,9 @@ func quitGame():
 	get_tree().network_peer = null
 	GameManager.reset()
 	if has_node("/root/OverWorld"): # Game is in progress.
-		# End it
 		get_node("/root/OverWorld").queue_free()
+	if has_node("/root/Dungeon"): # Game is in progress.
+		get_node("/root/Dungeon").queue_free()
 	get_node("/root/players").queue_free()
 	player_info = {}
 	get_tree().change_scene(GameManager.MULTIPLAYER_MENU)

--- a/LobbyManager.gd
+++ b/LobbyManager.gd
@@ -30,7 +30,7 @@ func _player_disconnected(id):
 # Only called on clients, not server. Will go unused; not useful here.
 func _connected_ok():
 	print("connected!")
-	get_tree().change_scene(GameManager.LOBBY_SCENE)
+	GameManager.change_scene(GameManager.LOBBY_SCENE)
 
 # Server kicked us; show error and abort.
 func _server_disconnected():
@@ -39,36 +39,36 @@ func _server_disconnected():
  # Could not even connect to server; abort.
 func _connected_fail():
 	print("unable to connect")
-	
+
 remote func register_player(info):
 	print("register player:", info)
 	# Get the id of the RPC sender.
 	var id = get_tree().get_rpc_sender_id()
 	# Store the info
 	player_info[id] = info
-	
+
 
 remote func pre_configure_game():
 
 	var selfPeerID = get_tree().get_network_unique_id()
 	if is_network_master():
 		GameManager.create_seed()
-		
-	#need to do the emit/signal stuff here, 1 will be the server so it should gen then others should 
+
+	#need to do the emit/signal stuff here, 1 will be the server so it should gen then others should
 	# consume the signal and get the new seed
 	#if 1 == selfPeerID:
 	#	GameManager.create_seed()
-	#else: 
+	#else:
 	#	GameManager.seed = rpc_id(selfPeerID, "get_initial_seed")
-		
+
 	# Load world
 
-	GameManager.change_scene("res://World/OverWorld.tscn")
-	
+	GameManager.change_scene(GameManager.OVERWORLD_SCENE)
+
 	var players_node = Node.new()
 	players_node.name = "players"
 	get_node("/root").add_child(players_node)
-	
+
 	# Load my player
 	var my_player = preload("res://Player/Player.tscn").instance()
 	my_player.set_name(str(selfPeerID))
@@ -92,7 +92,7 @@ remote func pre_configure_game():
 		post_configure_game()
 
 
-	
+
 remote func post_configure_game():
 	# Only the server is allowed to tell a client to unpause
 
@@ -101,20 +101,20 @@ remote func post_configure_game():
 		# Game starts now!
 
 func startGame():
-	
+
 	for player in LobbyManager.player_info:
 		rpc_id(player, "pre_configure_game")
 	pre_configure_game()
 
-	
+
 func joinGame(ip, port):
 	var peer = NetworkedMultiplayerENet.new()
 	peer.create_client(ip, port)
 	get_tree().network_peer = peer
 
-	
+
 func quitGame():
 	get_tree().network_peer = null
 	GameManager.reset()
 	player_info = {}
-	get_tree().change_scene(GameManager.MULTIPLAYER_MENU)
+	GameManager.change_scene(GameManager.MULTIPLAYER_MENU)

--- a/LobbyManager.gd
+++ b/LobbyManager.gd
@@ -49,13 +49,22 @@ remote func register_player(info):
 	
 
 remote func pre_configure_game():
-	if is_network_master():
-		GameManager.createSeed()
-	var selfPeerID = get_tree().get_network_unique_id()
 
+	var selfPeerID = get_tree().get_network_unique_id()
+	if is_network_master():
+		GameManager.create_seed()
+		
+	#need to do the emit/signal stuff here, 1 will be the server so it should gen then others should 
+	# consume the signal and get the new seed
+	#if 1 == selfPeerID:
+	#	GameManager.create_seed()
+	#else: 
+	#	GameManager.seed = rpc_id(selfPeerID, "get_initial_seed")
+		
 	# Load world
-	var world = load("res://World/OverWorld.tscn").instance()
-	get_node("/root").add_child(world)
+
+	GameManager.change_scene("res://World/OverWorld.tscn")
+	
 	var players_node = Node.new()
 	players_node.name = "players"
 	get_node("/root").add_child(players_node)
@@ -114,10 +123,5 @@ func joinGame(ip, port):
 func quitGame():
 	get_tree().network_peer = null
 	GameManager.reset()
-	if has_node("/root/OverWorld"): # Game is in progress.
-		get_node("/root/OverWorld").queue_free()
-	if has_node("/root/Dungeon"): # Game is in progress.
-		get_node("/root/Dungeon").queue_free()
-	get_node("/root/players").queue_free()
 	player_info = {}
 	get_tree().change_scene(GameManager.MULTIPLAYER_MENU)

--- a/LobbyManager.gd
+++ b/LobbyManager.gd
@@ -117,4 +117,4 @@ func quitGame():
 	get_tree().network_peer = null
 	GameManager.reset()
 	player_info = {}
-	GameManager.change_scene(GameManager.MULTIPLAYER_MENU)
+	get_tree().change_scene(GameManager.MULTIPLAYER_MENU)

--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -152,6 +152,7 @@ func _on_HurtBox_invincibility_ended():
 func _on_no_health():
 	print("player died!")
 	self.queue_free()
-	GameManager.change_scene(GameManager.GAME_OVER)
+	GameManager.reset()
+	get_tree().change_scene(GameManager.GAME_OVER_SCENE)
 
 	

--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -31,7 +31,7 @@ onready var hurtBox = $HurtBox
 onready var blinkPlayer = $FlashAnimationPlayer
 
 func _ready():
-	stats.connect("no_health", self, "queue_free")
+	stats.connect("no_health", self, "_on_no_health")
 	set_weapon_info()
 	animationTree.active = true
 	swordHitbox.knockback_vector = roll_vector
@@ -146,6 +146,12 @@ func _on_HurtBox_area_entered(area):
 func _on_HurtBox_invincibility_started():
 	blinkPlayer.play("Start")
 
-
 func _on_HurtBox_invincibility_ended():
 	blinkPlayer.play("Stop")
+
+func _on_no_health():
+	print("player died!")
+	self.queue_free()
+	GameManager.change_scene(GameManager.GAME_OVER)
+
+	

--- a/TeleportArea.gd
+++ b/TeleportArea.gd
@@ -1,4 +1,4 @@
 extends Area2D
 
 func _on_TeleportArea_body_entered(body):
-	get_tree().change_scene("res://World/Dungeon/Dungeon.tscn")
+	GameManager.change_scene(GameManager.DUNGEON_SCENE)

--- a/UI/screens/GameOver/GameOver.tscn
+++ b/UI/screens/GameOver/GameOver.tscn
@@ -1,8 +1,19 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=4 format=2]
 
-[ext_resource path="res://UI/screens/MultiplayerSetup/CreateServer.gd" type="Script" id=1]
+[ext_resource path="res://UI/screens/MultiplayerSetup/MultiplayerSetup.gd" type="Script" id=1]
+[ext_resource path="res://UI/screens/GameOver/GameOverButton.gd" type="Script" id=2]
 
-[node name="Node2D" type="Control"]
+[sub_resource type="ShaderMaterial" id=1]
+
+[node name="GameOver" type="Control"]
+material = SubResource( 1 )
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -160.0
+margin_right = 160.0
+script = ExtResource( 1 )
 
 [node name="BackgroundTile" type="ColorRect" parent="."]
 margin_top = -89.0
@@ -10,7 +21,7 @@ margin_right = 319.0
 margin_bottom = 87.0
 color = Color( 0, 0.227451, 0.521569, 1 )
 
-[node name="MainMenuButton" type="Button" parent="."]
+[node name="GameOverButton" type="Button" parent="."]
 pause_mode = 2
 anchor_left = 0.5
 anchor_top = 0.5
@@ -21,5 +32,12 @@ margin_top = -10.0
 margin_right = 48.5
 margin_bottom = 10.0
 rect_pivot_offset = Vector2( 32, 10 )
-text = "Create Server"
-script = ExtResource( 1 )
+text = "Main Menu"
+script = ExtResource( 2 )
+
+[node name="RichTextLabel" type="RichTextLabel" parent="."]
+margin_left = 99.2971
+margin_top = -53.8378
+margin_right = 243.297
+margin_bottom = -33.8378
+text = "Sucks to Suck Bruh"

--- a/UI/screens/GameOver/GameOver.tscn
+++ b/UI/screens/GameOver/GameOver.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://UI/screens/MultiplayerSetup/CreateServer.gd" type="Script" id=1]
+
+[node name="Node2D" type="Control"]
+
+[node name="BackgroundTile" type="ColorRect" parent="."]
+margin_top = -89.0
+margin_right = 319.0
+margin_bottom = 87.0
+color = Color( 0, 0.227451, 0.521569, 1 )
+
+[node name="MainMenuButton" type="Button" parent="."]
+pause_mode = 2
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -48.5
+margin_top = -10.0
+margin_right = 48.5
+margin_bottom = 10.0
+rect_pivot_offset = Vector2( 32, 10 )
+text = "Create Server"
+script = ExtResource( 1 )

--- a/UI/screens/GameOver/GameOverButton.gd
+++ b/UI/screens/GameOver/GameOverButton.gd
@@ -1,0 +1,17 @@
+extends Button
+
+
+# Declare member variables here. Examples:
+# var a = 2
+# var b = "text"
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	self.connect("pressed", self, "_button_pressed")
+
+func _button_pressed():
+	get_tree().change_scene(GameManager.MULTIPLAYER_MENU)
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+#func _process(delta):
+#	pass

--- a/UI/screens/Lobby/LeaveButton.gd
+++ b/UI/screens/Lobby/LeaveButton.gd
@@ -12,7 +12,7 @@ func _ready():
 
 func _button_pressed():
 	get_tree().network_peer = null
-	get_tree().change_scene(GameManager.MULTIPLAYER_MENU)
+	GameManager.change_scene(GameManager.MULTIPLAYER_MENU)
 
 
 

--- a/UI/screens/MultiplayerSetup/CreateServer.gd
+++ b/UI/screens/MultiplayerSetup/CreateServer.gd
@@ -14,6 +14,7 @@ func _button_pressed():
 	var peer = NetworkedMultiplayerENet.new()
 	peer.create_server(GameManager.SERVER_PORT, GameManager.MAX_PLAYERS)
 	get_tree().network_peer = peer
+	
 	print("server lisenting on: ", GameManager.SERVER_PORT)
 	get_tree().change_scene(GameManager.LOBBY_SCENE)
 

--- a/World/Dungeon/Dungeon.gd
+++ b/World/Dungeon/Dungeon.gd
@@ -39,7 +39,6 @@ func _on_ProceduralMazeLevel_addEntrance(position: Vector2):
 	var entrance = mapMaker.entranceScene.instance() as DungeonExit
 	entrance.position = position
 	var connectionResults = entrance.connect("exit_dungeon", self, "_on_exit_dungeon")
-	
 	entranceContainer.add_child(entrance)
 	
 func _on_exit_dungeon(body):
@@ -48,7 +47,7 @@ func _on_exit_dungeon(body):
 
 func confirm_exit():
 	print("show exit dungeon confirmation")
-	$CanvasLayer/ConfirmExit.popup_centered()
+	$CanvasLayer/ConfirmExit.popup_centered()  # FIXME doesn't pop up 
 
 func _on_ProceduralMazeLevel_addExits(positions):
 	for position in positions:

--- a/World/Dungeon/Dungeon.gd
+++ b/World/Dungeon/Dungeon.gd
@@ -48,7 +48,7 @@ func _on_exit_dungeon(body):
 
 func confirm_exit():
 	print("show exit dungeon confirmation")
- 	$CanvasLayer/ConfirmExit.popup_centered()
+	$CanvasLayer/ConfirmExit.popup_centered()
 
 func _on_ProceduralMazeLevel_addExits(positions):
 	for position in positions:

--- a/World/Dungeon/Dungeon.gd
+++ b/World/Dungeon/Dungeon.gd
@@ -18,7 +18,7 @@ var textureScale = 0.7
 func _ready():
 	var mapHeight = generator.tile_size * generator.mapHeight
 	var mapWidth = generator.tile_size * generator.mapWidth
-	
+
 	background.region_enabled = true
 	background.centered = false
 	print("Width:"+str(mapWidth))
@@ -30,7 +30,7 @@ func _ready():
 	#camera.limit_top = -backgroundBuffer
 	#camera.limit_right = mapWidth + backgroundBuffer
 	#camera.limit_bottom = mapHeight + backgroundBuffer
-	
+
 	mapMaker.make_maze()
 	#place enemies, treasures and exits. This is handled here so that the dungeon
 	#can determine the sprites for these things.
@@ -40,21 +40,21 @@ func _on_ProceduralMazeLevel_addEntrance(position: Vector2):
 	entrance.position = position
 	var connectionResults = entrance.connect("exit_dungeon", self, "_on_exit_dungeon")
 	entranceContainer.add_child(entrance)
-	
+
 func _on_exit_dungeon(body):
 	print("popup exit confirmation")
 	confirm_exit();
 
 func confirm_exit():
 	print("show exit dungeon confirmation")
-	$CanvasLayer/ConfirmExit.popup_centered()  # FIXME doesn't pop up 
+	$CanvasLayer/ConfirmExit.popup_centered()  # FIXME doesn't pop up
 
 func _on_ProceduralMazeLevel_addExits(positions):
 	for position in positions:
 		var exit = mapMaker.exitScene.instance()
 		exit.position = position
 		exitsContainer.add_child(exit)
-		
+
 
 func _on_ProceduralMazeLevel_addTreasure(positions):
 	if (mapMaker.treasureOptions.size() > 0):
@@ -65,7 +65,7 @@ func _on_ProceduralMazeLevel_addTreasure(positions):
 			treasure.position = position
 			treasuresContainer.add_child(treasure)
 
-func _on_ProceduralMazeLevel_addEnemies(positions):		
+func _on_ProceduralMazeLevel_addEnemies(positions):
 	if (mapMaker.enemyOptions.size() > 0):
 		var filteredEnemyOptions = getValidArrayIndexes(GameManager.level, mapMaker.enemySpawnLevels)
 		for position in positions:
@@ -81,16 +81,14 @@ func getValidArrayIndexes(var level: int, var levelList):
 		var itemLvl = levelList[n]
 		print(str(itemLvl) +" <= "+str(level) +" = "+str(itemLvl <= level))
 		if (itemLvl <= level):
-			validIndex.push_back(n)	
+			validIndex.push_back(n)
 	return validIndex
 
 
 func _on_ConfirmExit_confirmed():
-	get_tree().change_scene("res://World/OverWorld.tscn")
+	GameManager.change_scene(GameManager.OVERWORLD_SCENE)
 	var player = $SpriteLayer/Player
 	GameManager.level = 0
-	pass # Replace with function body.
-
 
 func _on_AudioStreamPlayer_finished():
 	$AudioStreamPlayer.play()

--- a/World/Dungeon/Dungeon.gd
+++ b/World/Dungeon/Dungeon.gd
@@ -3,7 +3,7 @@ extends Node2D
 const DungeonExit = preload("DungeonExit.gd")
 
 onready var mapMaker = $YSort/ProceduralMazeLevel
-onready var camera = $PlayerCamera
+#onready var camera = $PlayerCamera
 onready var background = $Background
 onready var generator = $YSort/ProceduralMazeLevel
 onready var entranceContainer = $YSort/Entrances
@@ -48,7 +48,7 @@ func _on_exit_dungeon(body):
 
 func confirm_exit():
 	print("show exit dungeon confirmation")
-	$CanvasLayer/ConfirmExit.popup_centered()
+ 	$CanvasLayer/ConfirmExit.popup_centered()
 
 func _on_ProceduralMazeLevel_addExits(positions):
 	for position in positions:

--- a/World/Dungeon/DungeonEntrance.gd
+++ b/World/Dungeon/DungeonEntrance.gd
@@ -7,7 +7,12 @@ func _on_DungeonEntrance_body_entered(body):
 	if (active):
 		GameManager.level += dungeonLevel
 		GameManager.levelSeed = (str(GameManager.initial_seed)+"_"+str(global_position)+"_"+str(dungeonLevel)).hash()
+
+
+		var world = load("res://World/OverWorld.tscn").instance()
+		get_node("/root").add_child(world)
 		get_tree().change_scene("res://World/Dungeon/Dungeon.tscn")
+
 
 func _on_DungeonEntrance_body_exited(body):
 	active = true

--- a/World/Dungeon/DungeonEntrance.gd
+++ b/World/Dungeon/DungeonEntrance.gd
@@ -8,10 +8,10 @@ func _on_DungeonEntrance_body_entered(body):
 		GameManager.level += dungeonLevel
 		GameManager.levelSeed = (str(GameManager.initial_seed)+"_"+str(global_position)+"_"+str(dungeonLevel)).hash()
 
-		GameManager.change_scene("res://World/Dungeon/Dungeon.tscn")
-		
-		# set player position only the one that entered 
-		var exit = get_node("/root/Dungeon/YSort/Entrances/DungeonExit")
+		GameManager.change_scene(GameManager.DUNGEON_SCENE)
+
+		# set player position only the one that entered
+		var exit = get_node("/root/world/YSort/Entrances/DungeonExit")
 		var position = Vector2(exit.position.x + 10, exit.position.y + 10)
 		body.position = position
 		body.get_node("Light").enabled = true

--- a/World/Dungeon/DungeonEntrance.gd
+++ b/World/Dungeon/DungeonEntrance.gd
@@ -9,7 +9,9 @@ func _on_DungeonEntrance_body_entered(body):
 		GameManager.levelSeed = (str(GameManager.initial_seed)+"_"+str(global_position)+"_"+str(dungeonLevel)).hash()
 
 		# remove old level
-		get_node("/root/Dungeon").queue_free()
+		var oldDungeon = get_node("/root/Dungeon")
+		oldDungeon.name = "oldDungeon"
+		oldDungeon.queue_free()
 		
 		# load the new level
 		var dungeon = load("res://World/Dungeon/Dungeon.tscn").instance()
@@ -23,6 +25,7 @@ func _on_DungeonEntrance_body_entered(body):
 		var exit = get_node("/root/Dungeon/YSort/Entrances/DungeonExit")
 		var position = Vector2(exit.position.x + 10, exit.position.y + 10)
 		body.position = position
+		body.get_node("Light").enabled = true
 
 
 func _on_DungeonEntrance_body_exited(body):

--- a/World/Dungeon/DungeonEntrance.gd
+++ b/World/Dungeon/DungeonEntrance.gd
@@ -8,7 +8,7 @@ func _on_DungeonEntrance_body_entered(body):
 		GameManager.level += dungeonLevel
 		GameManager.levelSeed = (str(GameManager.initial_seed)+"_"+str(global_position)+"_"+str(dungeonLevel)).hash()
 
-
+		
 		var world = load("res://World/OverWorld.tscn").instance()
 		get_node("/root").add_child(world)
 		get_tree().change_scene("res://World/Dungeon/Dungeon.tscn")

--- a/World/Dungeon/DungeonEntrance.gd
+++ b/World/Dungeon/DungeonEntrance.gd
@@ -8,18 +8,7 @@ func _on_DungeonEntrance_body_entered(body):
 		GameManager.level += dungeonLevel
 		GameManager.levelSeed = (str(GameManager.initial_seed)+"_"+str(global_position)+"_"+str(dungeonLevel)).hash()
 
-		# remove old level
-		var oldDungeon = get_node("/root/Dungeon")
-		oldDungeon.name = "oldDungeon"
-		oldDungeon.queue_free()
-		
-		# load the new level
-		var dungeon = load("res://World/Dungeon/Dungeon.tscn").instance()
-		var root = get_node("/root")
-
-		root.add_child(dungeon)
-		# fix players index
-		root.move_child(get_node("/root/players"), root.get_child_count() -1)
+		GameManager.change_scene("res://World/Dungeon/Dungeon.tscn")
 		
 		# set player position only the one that entered 
 		var exit = get_node("/root/Dungeon/YSort/Entrances/DungeonExit")

--- a/World/Dungeon/DungeonEntrance.gd
+++ b/World/Dungeon/DungeonEntrance.gd
@@ -8,10 +8,21 @@ func _on_DungeonEntrance_body_entered(body):
 		GameManager.level += dungeonLevel
 		GameManager.levelSeed = (str(GameManager.initial_seed)+"_"+str(global_position)+"_"+str(dungeonLevel)).hash()
 
+		# remove old level
+		get_node("/root/Dungeon").queue_free()
 		
-		var world = load("res://World/OverWorld.tscn").instance()
-		get_node("/root").add_child(world)
-		get_tree().change_scene("res://World/Dungeon/Dungeon.tscn")
+		# load the new level
+		var dungeon = load("res://World/Dungeon/Dungeon.tscn").instance()
+		var root = get_node("/root")
+
+		root.add_child(dungeon)
+		# fix players index
+		root.move_child(get_node("/root/players"), root.get_child_count() -1)
+		
+		# set player position only the one that entered 
+		var exit = get_node("/root/Dungeon/YSort/Entrances/DungeonExit")
+		var position = Vector2(exit.position.x + 10, exit.position.y + 10)
+		body.position = position
 
 
 func _on_DungeonEntrance_body_exited(body):

--- a/World/OverWorld.gd
+++ b/World/OverWorld.gd
@@ -25,4 +25,5 @@ func readyDungeonEntrances():
 
 func _on_OverworldDungeonEntrance_body_entered(body):
 	print("show entrance dialog")
-	entrance.show_dialog()
+	entrance.show_dialog(body)
+

--- a/World/OverWorld.tscn
+++ b/World/OverWorld.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=79 format=2]
+[gd_scene load_steps=78 format=2]
 
 [ext_resource path="res://World/Bush.tscn" type="PackedScene" id=1]
-[ext_resource path="res://Player/Player.tscn" type="PackedScene" id=2]
 [ext_resource path="res://World/GrassBackground.png" type="Texture" id=3]
 [ext_resource path="res://World/DirtTileset.png" type="Texture" id=4]
 [ext_resource path="res://World/CliffTileset.png" type="Texture" id=5]
@@ -570,7 +569,6 @@ summonOptions = [ ExtResource( 17 ), ExtResource( 14 ) ]
 
 [node name="Sprite" parent="SpriteLayer/DarkWizard" index="5"]
 material = SubResource( 52 )
-frame = 0
 
 [node name="Stats" parent="SpriteLayer/DarkWizard" index="7"]
 level = 5
@@ -714,10 +712,6 @@ position = Vector2( 168.858, 264 )
 
 [node name="RustySwordPickup" parent="." instance=ExtResource( 19 )]
 position = Vector2( 120.613, 232 )
-
-[node name="players" type="Node" parent="."]
-
-[node name="Player" parent="players" instance=ExtResource( 2 )]
 
 [connection signal="body_entered" from="OverworldDungeonEntrance" to="." method="_on_OverworldDungeonEntrance_body_entered"]
 

--- a/World/OverworldDungeonEntrance.gd
+++ b/World/OverworldDungeonEntrance.gd
@@ -17,16 +17,10 @@ func _on_ConfirmationDialog_confirmed():
 	GameManager.levelSeed = (str(GameManager.initial_seed)+"_"+str(global_position)+"_"+str(dungeonLevel)).hash()
 	
 	# load the new level
-	var dungeon = load("res://World/Dungeon/Dungeon.tscn").instance()
-	var root = get_node("/root")
-	# remove old level
-	get_node("/root/OverWorld").queue_free()
-	root.add_child(dungeon)
-	# fix players index
-	root.move_child(get_node("/root/players"), root.get_child_count() -1)
+	GameManager.change_scene("res://World/Dungeon/Dungeon.tscn")
 	
 	# set player position only the one that entered 
-	var exit = get_node("/root/Dungeon/YSort/Entrances/DungeonExit")
+	var exit = get_node("/root/world/YSort/Entrances/DungeonExit")
 	var position = Vector2(exit.position.x + 10, exit.position.y + 10)
 	body.position = position
 

--- a/World/OverworldDungeonEntrance.gd
+++ b/World/OverworldDungeonEntrance.gd
@@ -1,7 +1,7 @@
 extends Area2D
 
 var active = false
-var body 
+var body
 export(int) var dungeonLevel = 1
 
 func show_dialog(body):
@@ -15,15 +15,15 @@ func _on_ConfirmationDialog_confirmed():
 	GameManager.level = dungeonLevel
 	GameManager.overworld_entrance_position = global_position
 	GameManager.levelSeed = (str(GameManager.initial_seed)+"_"+str(global_position)+"_"+str(dungeonLevel)).hash()
-	
+
 	# load the new level
-	GameManager.change_scene("res://World/Dungeon/Dungeon.tscn")
-	
-	# set player position only the one that entered 
+	GameManager.change_scene(GameManager.DUNGEON_SCENE)
+
+	# set player position only the one that entered
 	var exit = get_node("/root/world/YSort/Entrances/DungeonExit")
 	var position = Vector2(exit.position.x + 10, exit.position.y + 10)
 	body.position = position
 
 
 
-	
+

--- a/World/OverworldDungeonEntrance.gd
+++ b/World/OverworldDungeonEntrance.gd
@@ -13,8 +13,10 @@ func _on_ConfirmationDialog_confirmed():
 	GameManager.level = dungeonLevel
 	GameManager.overworld_entrance_position = global_position
 	GameManager.levelSeed = (str(GameManager.initial_seed)+"_"+str(global_position)+"_"+str(dungeonLevel)).hash()
+	
 	var dungeon = load("res://World/Dungeon/Dungeon.tscn").instance()
 	var root = get_node("/root")
+	get_node("/root/OverWorld").queue_free()
 	root.add_child(dungeon)
 	root.move_child(get_node("/root/players"), root.get_child_count() -1)
 

--- a/World/OverworldDungeonEntrance.gd
+++ b/World/OverworldDungeonEntrance.gd
@@ -1,9 +1,11 @@
 extends Area2D
 
 var active = false
+var body 
 export(int) var dungeonLevel = 1
 
-func show_dialog():
+func show_dialog(body):
+	self.body = body
 	$CanvasLayer/ConfirmationDialog.popup_centered()
 
 signal enter_dungeon_confirmed
@@ -14,11 +16,19 @@ func _on_ConfirmationDialog_confirmed():
 	GameManager.overworld_entrance_position = global_position
 	GameManager.levelSeed = (str(GameManager.initial_seed)+"_"+str(global_position)+"_"+str(dungeonLevel)).hash()
 	
+	# load the new level
 	var dungeon = load("res://World/Dungeon/Dungeon.tscn").instance()
 	var root = get_node("/root")
+	# remove old level
 	get_node("/root/OverWorld").queue_free()
 	root.add_child(dungeon)
+	# fix players index
 	root.move_child(get_node("/root/players"), root.get_child_count() -1)
+	
+	# set player position only the one that entered 
+	var exit = get_node("/root/Dungeon/YSort/Entrances/DungeonExit")
+	var position = Vector2(exit.position.x + 10, exit.position.y + 10)
+	body.position = position
 
 
 


### PR DESCRIPTION
## updates
- **some menu scenes still use get_tree().change_scene**--this is intentional for now, the standard method won't currently looks for the names of the various menus to free them, so we can either leave as get_tree or rename them to "world" or "main" along with the levels (those are currentley always named "world" or "prev_world" to resolve, want to discuss
- dugeon entry fixed for primary and subsequent 
- player hit flash fix bug fixed
- GameManger.change_scene method
- game over scene and replay from game over

## things to note:
- if server dies currently the whole game is done because it quits to game over screen
- exiting dungeons still needs to be corrected/implemented
- when two players enter dungeon they enter diff ones
  - all players are creating their own seed, put a comment for how to fix that with signals
- flashlight, sometimes you have to hit the button a few times to turn it on which is werid
